### PR TITLE
Implement step waiting for AMQP

### DIFF
--- a/runner.rb
+++ b/runner.rb
@@ -2,6 +2,7 @@
 
 require 'yaml'
 require_relative './steps/run_step'
+require_relative './steps/wait_for_amqp_step'
 require_relative './steps/wait_for_port_step'
 require_relative './steps/wait_for_postgres_step'
 require_relative './steps/wait_step'
@@ -41,6 +42,8 @@ module Runner
           RunStep.call(value)
         when "wait"
           WaitStep.call(value)
+        when "wait_for_amqp"
+          WaitForAmqpStep.call(value)
         when "wait_for_port"
           WaitForPortStep.call(value)
         when "wait_for_postgres"

--- a/steps/wait_for_amqp_step.rb
+++ b/steps/wait_for_amqp_step.rb
@@ -1,0 +1,49 @@
+require "socket"
+require "uri"
+
+module Runner
+  class WaitForAmqpStep
+    class << self
+      def call(url)
+        uri = url =~ /^amqp:\/\// ? URI.parse(url) : URI.parse("amqp://#{url}")
+        host = uri.host
+        port = uri.port || 5672
+        final_url = "#{host}:#{port}"
+
+        puts "Waiting for AMQP on '#{final_url}'"
+
+        30.times do
+          return true if amqp_ready_for_query?(host, port)
+
+          sleep 1
+        end
+
+        puts "Failure waiting for AMQP on '#{final_url}'"
+      end
+
+      private
+
+      def amqp_ready_for_query?(host, port)
+        # Connect to AMQP and send Preamble packet
+        socket = TCPSocket.new(host, port)
+        socket.write("AMQP\x00\x00\x09\x01")
+
+        # Read initial response attributes
+        type, channel, length, klass, amqp_method = socket.read(11).unpack("C S> L> S> S>")
+
+        # Type == 1 means Method
+        # Class == 10 means Connection
+        # Method == 10 means Start
+        if [type, klass, amqp_method] == [1, 10, 10]
+          return true
+        end
+
+        false
+      rescue Errno::ECONNREFUSED => error
+        false
+      ensure
+        socket.close if socket
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Overview

This steps tries to connect to AMQP server and check for valid response in AMQP protocol. Such method can help us avoid situations when AMQP port is open, but server is not yet ready to accept connections.